### PR TITLE
Sagas with multiple starting messages should be correlated properly

### DIFF
--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/NServiceBus.AzureStoragePersistence.AcceptanceTests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/NServiceBus.AzureStoragePersistence.AcceptanceTests.csproj
@@ -44,6 +44,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
@@ -112,6 +113,7 @@
     <Compile Include="Sagas\When_saga_has_a_non_empty_constructor.cs" />
     <Compile Include="Sagas\When_saga_id_changed.cs" />
     <Compile Include="Sagas\When_saga_is_mapped_to_complex_expression.cs" />
+    <Compile Include="Sagas\When_saga_is_started_by_two_types_of_messages.cs" />
     <Compile Include="Sagas\When_sending_from_a_saga_handle.cs" />
     <Compile Include="Sagas\When_sending_from_a_saga_timeout.cs" />
     <Compile Include="Sagas\When_started_by_base_event_from_other_saga.cs" />

--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -60,8 +60,7 @@
                 .Done(c => c.DidRequestingSagaGetTheResponse)
                 .Run(new RunSettings
                 {
-                    UseSeparateAppDomains = true,
-                    TestExecutionTimeout = TimeSpan.FromSeconds(15)
+                    UseSeparateAppDomains = true
                 });
 
             Assert.True(context.DidRequestingSagaGetTheResponse);

--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
@@ -74,6 +74,7 @@
 
                 public class TestSagaData : ContainSagaData
                 {
+                    [Unique]
                     public string SomeId { get; set; }
                 }
             }

--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
@@ -1,0 +1,156 @@
+﻿namespace NServiceBus.AzureStoragePersistence.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Config.ConfigurationSource;
+    using NServiceBus.Saga;
+    using NServiceBus.SagaPersisters.Azure;
+    using NUnit.Framework;
+
+    public class When_saga_is_started_by_two_types_of_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Every_saga_should_be_started_once_and_updated_by_second_message()
+        {
+            const int expectedNumberOfCreatedSagas = 20;
+
+            var guids = new HashSet<string>(Enumerable.Repeat(1, expectedNumberOfCreatedSagas).Select(i => Guid.NewGuid().ToString())).OrderBy(s => s);
+
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) =>
+                    {
+                        foreach (var guid in guids)
+                        {
+                            bus.SendLocal(new OrderBilled
+                            {
+                                OrderId = guid
+                            });
+                            bus.SendLocal(new OrderPlaced
+                            {
+                                OrderId = guid
+                            });
+                        }
+                    }))
+                    .AllowExceptions()
+                    .Done(c => c.CompletedIds.OrderBy(s => s).ToArray().Intersect(guids).Count() == expectedNumberOfCreatedSagas)
+                    .Run();
+
+            CollectionAssert.AreEquivalent(guids, context.CompletedIds.OrderBy(s => s).ToArray());
+
+            var retries = AllIndexesOf(context.Exceptions, typeof(RetryNeededException).FullName).Count();
+            Console.WriteLine($"Sagas with retries/Total no of sagas {retries}/{expectedNumberOfCreatedSagas}");
+        }
+
+        private static IEnumerable<int> AllIndexesOf(string str, string value)
+        {
+            for (int index = 0; ; index += value.Length)
+            {
+                index = str.IndexOf(value, index, StringComparison.Ordinal);
+                if (index == -1)
+                    yield break;
+                yield return index;
+            }
+        }
+
+        public class ProvideConfiguration : IProvideConfiguration<TransportConfig>
+        {
+            public TransportConfig GetConfiguration()
+            {
+                return new TransportConfig
+                {
+                    MaximumConcurrencyLevel = 3,
+                };
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            private readonly ConcurrentDictionary<string, string> completed = new ConcurrentDictionary<string, string>();
+            public int CompletedIdsCount => completed.Count;
+            public IEnumerable<string> CompletedIds => completed.Keys;
+
+            public void MarkAsCompleted(string orderId)
+            {
+                completed.AddOrUpdate(orderId, orderId, (o1, o2) => o1);
+            }
+        }
+
+        public class ReceiverWithSagas : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSagas()
+            {
+                EndpointSetup<DefaultServer>(
+                    config =>
+                    { });
+            }
+        }
+
+        public class ShippingPolicy : Saga<ShippingPolicy.State>,
+            IAmStartedByMessages<OrderPlaced>,
+            IAmStartedByMessages<OrderBilled>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(OrderBilled message)
+            {
+                Data.OrderId = message.OrderId;
+                Data.Billed = true;
+
+                TryComplete();
+            }
+
+            public void Handle(OrderPlaced message)
+            {
+                Data.OrderId = message.OrderId;
+                Data.Placed = true;
+
+                TryComplete();
+            }
+
+            private void TryComplete()
+            {
+                if (Data.Billed && Data.Placed)
+                {
+                    MarkAsComplete();
+                    Context.MarkAsCompleted(Data.OrderId);
+                }
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<State> mapper)
+            {
+                mapper.ConfigureMapping<OrderPlaced>(m => m.OrderId)
+                    .ToSaga(s => s.OrderId);
+                mapper.ConfigureMapping<OrderBilled>(m => m.OrderId)
+                    .ToSaga(s => s.OrderId);
+            }
+
+            public class State : IContainSagaData
+            {
+                [Unique]
+                public virtual string OrderId { get; set; }
+                public virtual bool Placed { get; set; }
+                public virtual bool Billed { get; set; }
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+            }
+        }
+
+        public class OrderBilled : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class OrderPlaced : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
@@ -65,6 +65,7 @@
                 }
                 public class RequestingSagaData : ContainSagaData
                 {
+                    [Unique]
                     public virtual Guid CorrIdForResponse { get; set; } //wont be needed in the future
                 }
             }

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/NServiceBus.AzureStoragePersistence.ComponentTests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/NServiceBus.AzureStoragePersistence.ComponentTests.csproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <Compile Include="AzurePersistenceTests.cs" />
     <Compile Include="Persisters\When_using_GlobalConnectionStringConfiguration.cs" />
+    <Compile Include="Sagas\IndexDefinitionTests.cs" />
     <Compile Include="Sagas\When_completing_saga.cs" />
     <Compile Include="Sagas\When_updating_saga.cs" />
     <Compile Include="Sagas\When_saving_saga.cs" />

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/NServiceBus.AzureStoragePersistence.ComponentTests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/NServiceBus.AzureStoragePersistence.ComponentTests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Sagas\When_updating_saga.cs" />
     <Compile Include="Sagas\When_saving_saga.cs" />
     <Compile Include="Sagas\When_getting_the_saga_entity.cs" />
+    <Compile Include="Sagas\LRUCacheTests.cs" />
     <Compile Include="Persisters\When_using_AzureTimeoutStorageGuard.cs" />
     <Compile Include="Persisters\When_using_AzureStorageSagaGuard.cs" />
     <Compile Include="Persisters\When_using_AzureSubscriptionStorageGuard.cs" />

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/Sagas/IndexDefinitionTests.cs
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/Sagas/IndexDefinitionTests.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AzureStoragePersistence.ComponentTests.Sagas
+{
+    using System;
+    using Saga;
+    using SagaPersisters.Azure.SecondaryIndeces;
+    using NUnit.Framework;
+
+    public class IndexDefinitionTests
+    {
+        readonly IndexDefintion index;
+
+        private class SagaData : ContainSagaData
+        {
+            [Unique]
+            public string AdditionalId { get; set; }
+        }
+
+        public IndexDefinitionTests()
+        {
+            index = IndexDefintion.Get(typeof(SagaData));
+        }
+
+        [Test]
+        public void Should_access_value_properly()
+        {
+            const string id = "FF4E1C4E-D2F2-4601-8D8E-CB3E91872043";
+            var sagaData = new SagaData
+            {
+                AdditionalId = id
+            };
+
+            Assert.AreEqual(id, index.Accessor(sagaData));
+        }
+
+        [Test]
+        public void Should_validate_property()
+        {
+            Assert.Throws<ArgumentException>(() => index.ValidateProperty("AdditionalId_"));
+
+            index.ValidateProperty("AdditionalId");
+        }
+
+        [Test]
+        public void Should_build_index_key()
+        {
+            const string id = "C4D91B59-A407-4CDA-A689-60AA3C334699";
+            var key = index.BuildTableKey(id);
+            Assert.AreEqual("Index_NServiceBus.AzureStoragePersistence.ComponentTests.Sagas.IndexDefinitionTests+SagaData_AdditionalId_\"C4D91B59-A407-4CDA-A689-60AA3C334699\"", key.PartitionKey);
+            Assert.AreEqual("", key.RowKey);
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/Sagas/LRUCacheTests.cs
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/Sagas/LRUCacheTests.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AzureStoragePersistence.Tests
+{
+    using NServiceBus.SagaPersisters.Azure.SecondaryIndeces;
+    using NUnit.Framework;
+
+    public class LRUCacheTests
+    {
+        public class When_cache_is_empty
+        {
+            private readonly LRUCache<int, int> Empty = new LRUCache<int, int>(0);
+
+            [Test]
+            public void Should_not_throw_on_remove()
+            {
+                Empty.Remove(1);
+            }
+
+            [Test]
+            public void Should_not_find_any_value()
+            {
+                AssertNoValue(Empty, 1);
+            }
+        }
+
+        public class When_cache_is_full
+        {
+            private LRUCache<int, int> cache;
+            private const int Key1 = 1;
+            private const int Key2 = 2;
+            private const int Key3 = 3;
+            private const int Value1 = 11;
+            private const int Value11 = 111;
+            private const int Value2 = 22;
+            private const int Value3 = 32;
+
+            [SetUp]
+            public void SetUp()
+            {
+                cache = new LRUCache<int, int>(2);
+                cache.Put(Key1, Value1);
+                cache.Put(Key2, Value2);
+            }
+
+            [Test]
+            public void Should_preserve_values()
+            {
+                AssertValue(cache, Key1, Value1);
+                AssertValue(cache, Key2, Value2);
+            }
+
+            [Test]
+            public void Should_add_new_value_removing_the_oldest()
+            {
+                cache.Put(Key3, Value3);
+
+                AssertNoValue(cache, Key1);
+                AssertValue(cache, Key2, Value2);
+                AssertValue(cache, Key3, Value3);
+            }
+
+            [Test]
+            public void Should_update_existing_value_reordering_lru_properly()
+            {
+                cache.Put(Key1, Value11);
+                cache.Put(Key3, Value3);
+
+                AssertNoValue(cache, Key2);
+                AssertValue(cache, Key1, Value11);
+                AssertValue(cache, Key3, Value3);
+            }
+
+            [Test]
+            public void Should_create_a_slot_when_removing()
+            {
+                cache.Remove(Key2);
+                cache.Put(Key3, Value3);
+
+                AssertNoValue(cache, Key2);
+                AssertValue(cache, Key1, Value1);
+                AssertValue(cache, Key3, Value3);
+            }
+        }
+
+        private static void AssertValue(LRUCache<int, int> lruCache, int key, int expectedValue)
+        {
+            int value;
+            Assert.IsTrue(lruCache.TryGet(key, out value));
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        private static void AssertNoValue(LRUCache<int, int> lruCache, int key)
+        {
+            int value;
+            var tryGet = lruCache.TryGet(key, out value);
+            Assert.AreEqual(false, tryGet);
+            Assert.AreEqual(default(int), value);
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/NServiceBus.AzureStoragePersistence.csproj
+++ b/src/NServiceBus.AzureStoragePersistence/NServiceBus.AzureStoragePersistence.csproj
@@ -112,6 +112,12 @@
     <Compile Include="SagaPersisters\AzureStorageSagaGuard.cs" />
     <Compile Include="SagaPersisters\AzureStorageSagaDefaults.cs" />
     <Compile Include="SagaPersisters\Azure\AzureStorageSagaPersistence.cs" />
+    <Compile Include="SagaPersisters\Azure\RetryNeededException.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\LRUCache.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\PartitionRowKeyTuple.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SagaDataSerializer.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SecondaryIndexPersister.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SecondaryIndexTableEntity.cs" />
     <Compile Include="SagaPersisters\ConfigureAzureSagaStorage.cs" />
     <Compile Include="Subscriptions\AzureSubscriptionStorageGuard.cs" />
     <Compile Include="Subscriptions\Azure\AzureStorageSubscriptionPersistence.cs" />
@@ -139,6 +145,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\Particular.CodeRules.0.1.0\tools\..\analyzers\dotnet\cs\Particular.CodeRules.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/NServiceBus.AzureStoragePersistence/NServiceBus.AzureStoragePersistence.csproj
+++ b/src/NServiceBus.AzureStoragePersistence/NServiceBus.AzureStoragePersistence.csproj
@@ -113,6 +113,7 @@
     <Compile Include="SagaPersisters\AzureStorageSagaDefaults.cs" />
     <Compile Include="SagaPersisters\Azure\AzureStorageSagaPersistence.cs" />
     <Compile Include="SagaPersisters\Azure\RetryNeededException.cs" />
+    <Compile Include="SagaPersisters\Azure\SecondaryIndeces\IndexDefintion.cs" />
     <Compile Include="SagaPersisters\Azure\SecondaryIndeces\LRUCache.cs" />
     <Compile Include="SagaPersisters\Azure\SecondaryIndeces\PartitionRowKeyTuple.cs" />
     <Compile Include="SagaPersisters\Azure\SecondaryIndeces\SagaDataSerializer.cs" />

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/AzureSagaPersister.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/AzureSagaPersister.cs
@@ -3,12 +3,12 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Net;
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
     using NServiceBus.Azure;
+    using NServiceBus.SagaPersisters.Azure.SecondaryIndeces;
     using Saga;
 
     /// <summary>
@@ -18,9 +18,11 @@
     {
         readonly bool autoUpdateSchema;
         readonly CloudTableClient client;
+        readonly SecondaryIndexPersister secondaryIndeces;
+
         static readonly ConcurrentDictionary<string, bool> tableCreated = new ConcurrentDictionary<string, bool>();
         static readonly ConditionalWeakTable<object, string> etags = new ConditionalWeakTable<object, string>();
-        
+
         /// <summary>
         /// 
         /// </summary>
@@ -31,6 +33,7 @@
             this.autoUpdateSchema = autoUpdateSchema;
             var account = CloudStorageAccount.Parse(connectionString);
             client = account.CreateCloudTableClient();
+            secondaryIndeces = new SecondaryIndexPersister(GetTable, ScanForSaga, Persist);
         }
 
         /// <summary>
@@ -40,6 +43,7 @@
         /// <param name="saga">The saga entity that will be saved.</param>
         public void Save(IContainSagaData saga)
         {
+            secondaryIndeces.Insert(saga);
             Persist(saga);
         }
 
@@ -74,7 +78,6 @@
             return entity;
         }
 
-
         DictionaryTableEntity GetDictionaryTableEntity(string sagaId, Type entityType)
         {
             var tableName = entityType.Name;
@@ -88,38 +91,13 @@
 
         T ISagaPersister.Get<T>(string property, object value)
         {
-            var type = typeof(T);
-            var tableEntity = GetDictionaryTableEntity(type, property, value);
-            var entity = (T) ToEntity(type, tableEntity);
-
-            if (!Equals(entity, default(T)))
+            var sagaId = secondaryIndeces.FindPossiblyCreatingIndexEntry<T>(property, value);
+            if (sagaId != null)
             {
-                etags.Add(entity, tableEntity.ETag);
+                return Get<T>(sagaId.Value);
             }
 
-            try
-            {
-                return entity;
-            }
-            catch (WebException ex)
-            {
-                // can occur when table has not yet been created, but already looking for absence of instance
-                if (ex.Status == WebExceptionStatus.ProtocolError && ex.Response != null)
-                {
-                    var response = (HttpWebResponse) ex.Response;
-                    if (response.StatusCode == HttpStatusCode.NotFound)
-                    {
-                        return default(T);
-                    }
-                }
-
-                throw;
-            }
-            catch (StorageException)
-            {
-                // can occur when table has not yet been created, but already looking for absence of instance
-                return default(T);
-            }
+            return default(T);
         }
 
         DictionaryTableEntity GetDictionaryTableEntity(Type type, string property, object value)
@@ -133,35 +111,35 @@
 
             if (propertyInfo.PropertyType == typeof(byte[]))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBinary(property, QueryComparisons.Equal, (byte[]) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBinary(property, QueryComparisons.Equal, (byte[])value));
             }
             else if (propertyInfo.PropertyType == typeof(bool))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(property, QueryComparisons.Equal, (bool) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(property, QueryComparisons.Equal, (bool)value));
             }
             else if (propertyInfo.PropertyType == typeof(DateTime))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDate(property, QueryComparisons.Equal, (DateTime) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDate(property, QueryComparisons.Equal, (DateTime)value));
             }
             else if (propertyInfo.PropertyType == typeof(Guid))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForGuid(property, QueryComparisons.Equal, (Guid) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForGuid(property, QueryComparisons.Equal, (Guid)value));
             }
             else if (propertyInfo.PropertyType == typeof(Int32))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForInt(property, QueryComparisons.Equal, (int) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForInt(property, QueryComparisons.Equal, (int)value));
             }
             else if (propertyInfo.PropertyType == typeof(Int64))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForLong(property, QueryComparisons.Equal, (long) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForLong(property, QueryComparisons.Equal, (long)value));
             }
             else if (propertyInfo.PropertyType == typeof(Double))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDouble(property, QueryComparisons.Equal, (double) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDouble(property, QueryComparisons.Equal, (double)value));
             }
             else if (propertyInfo.PropertyType == typeof(string))
             {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition(property, QueryComparisons.Equal, (string) value));
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition(property, QueryComparisons.Equal, (string)value));
             }
             else
             {
@@ -197,21 +175,38 @@
         void Persist(IContainSagaData saga)
         {
             var type = saga.GetType();
-            var tableName = type.Name;
+            var table = GetTable(type);
+
+            var partitionKey = saga.Id.ToString();
+
+            var batch = new TableBatchOperation();
+
+            AddObjectToBatch(batch, saga, partitionKey);
+
+            table.ExecuteBatch(batch);
+        }
+
+        private CloudTable GetTable(Type sagaType)
+        {
+            var tableName = sagaType.Name;
             var table = client.GetTableReference(tableName);
             if (autoUpdateSchema && !tableCreated.ContainsKey(tableName))
             {
                 table.CreateIfNotExists();
                 tableCreated[tableName] = true;
             }
+            return table;
+        }
 
-            var partitionKey = saga.Id.ToString();
-                
-            var batch = new TableBatchOperation();
+        private Guid? ScanForSaga(Type sagatype, string propertyName, object propertyValue)
+        {
+            var entity = GetDictionaryTableEntity(sagatype, propertyName, propertyValue);
+            if (entity == null)
+            {
+                return null;
+            }
 
-            AddObjectToBatch(batch, saga, partitionKey);
-
-            table.ExecuteBatch(batch);
+            return Guid.ParseExact(entity.PartitionKey, "D");
         }
 
         void AddObjectToBatch(TableBatchOperation batch, object entity, string partitionKey, string rowkey = "")
@@ -222,39 +217,44 @@
             string etag;
             var update = etags.TryGetValue(entity, out etag);
 
-            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var properties = SelectPropertiesToPersist(type);
 
-            var toPersist = ToDictionaryTableEntity(entity, new DictionaryTableEntity { PartitionKey = partitionKey, RowKey = rowkey, ETag = etag}, properties);
+            var toPersist = ToDictionaryTableEntity(entity, new DictionaryTableEntity { PartitionKey = partitionKey, RowKey = rowkey, ETag = etag }, properties);
 
             //no longer using InsertOrReplace as it ignores concurrency checks
             batch.Add(update ? TableOperation.Replace(toPersist) : TableOperation.Insert(toPersist));
+        }
+
+        internal static PropertyInfo[] SelectPropertiesToPersist(Type sagaType)
+        {
+            return sagaType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         }
 
         DictionaryTableEntity ToDictionaryTableEntity(object entity, DictionaryTableEntity toPersist, IEnumerable<PropertyInfo> properties)
         {
             foreach (var propertyInfo in properties)
             {
-                if (propertyInfo.PropertyType == typeof (byte[]))
+                if (propertyInfo.PropertyType == typeof(byte[]))
                 {
-                    toPersist[propertyInfo.Name]= new EntityProperty((byte[]) propertyInfo.GetValue(entity, null)) ;
+                    toPersist[propertyInfo.Name] = new EntityProperty((byte[])propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (bool))
+                else if (propertyInfo.PropertyType == typeof(bool))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((bool)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (DateTime))
+                else if (propertyInfo.PropertyType == typeof(DateTime))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((DateTime)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (Guid))
+                else if (propertyInfo.PropertyType == typeof(Guid))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Guid)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (Int32))
+                else if (propertyInfo.PropertyType == typeof(Int32))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Int32)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (Int64))
+                else if (propertyInfo.PropertyType == typeof(Int64))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Int64)propertyInfo.GetValue(entity, null));
                 }
@@ -262,7 +262,7 @@
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((Double)propertyInfo.GetValue(entity, null));
                 }
-                else if (propertyInfo.PropertyType == typeof (string))
+                else if (propertyInfo.PropertyType == typeof(string))
                 {
                     toPersist[propertyInfo.Name] = new EntityProperty((string)propertyInfo.GetValue(entity, null));
                 }
@@ -334,6 +334,6 @@
             return toCreate;
         }
     }
-    
-  
+
+
 }

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/AzureStorageSagaPersistence.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/AzureStorageSagaPersistence.cs
@@ -24,8 +24,8 @@
         {
             var connectionstring = context.Settings.Get<string>("AzureSagaStorage.ConnectionString");
             var updateSchema = context.Settings.Get<bool>("AzureSagaStorage.CreateSchema");
-            
-            context.Container.ConfigureComponent(() => new AzureSagaPersister(connectionstring, updateSchema), DependencyLifecycle.InstancePerCall);
+
+            context.Container.ConfigureComponent(builder => new AzureSagaPersister(connectionstring, updateSchema), DependencyLifecycle.InstancePerCall);
         }
     }
 }

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/RetryNeededException.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/RetryNeededException.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.SagaPersisters.Azure
+{
+    using System;
+
+    public class RetryNeededException : Exception
+    {
+        public RetryNeededException() : base("This operation requires a retry as it wasn't possible to successfully process it now.")
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/IndexDefintion.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/IndexDefintion.cs
@@ -1,0 +1,75 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using NServiceBus.Saga;
+
+    public sealed class IndexDefintion
+    {
+        static readonly ConcurrentDictionary<Type, object> sagaToIndex = new ConcurrentDictionary<Type, object>();
+        static readonly object NullValue = new object();
+
+        static readonly ParameterExpression ObjectParameter = Expression.Parameter(typeof(object));
+        readonly string propertyName;
+
+        readonly string sagaTypeName;
+
+        private IndexDefintion(Type sagaType, PropertyInfo pi)
+        {
+            sagaTypeName = sagaType.FullName;
+            propertyName = pi.Name;
+            Accessor = Expression.Lambda<Func<object, object>>(Expression.Convert(Expression.MakeMemberAccess(Expression.Convert(ObjectParameter, sagaType), pi), typeof(object)), ObjectParameter).Compile();
+        }
+
+        public Func<object, object> Accessor { get; }
+
+        public static IndexDefintion Get(Type sagaType)
+        {
+            var index = sagaToIndex.GetOrAdd(sagaType, type =>
+            {
+                var pi = UniqueAttribute.GetUniqueProperty(sagaType);
+                if (pi == null)
+                {
+                    return NullValue;
+                }
+
+                return new IndexDefintion(sagaType, pi);
+            });
+
+            if (ReferenceEquals(index, NullValue))
+            {
+                return null;
+            }
+
+            return (IndexDefintion) index;
+        }
+
+        public void ValidateProperty(string propertyName)
+        {
+            if (this.propertyName != propertyName)
+            {
+                throw new ArgumentException($"The following saga '{sagaTypeName}' is not indexed by '{propertyName}'. The only secondary index is defined for '{this.propertyName}'. " +
+                                            $"Ensure that the saga is correlated properly.");
+            }
+        }
+
+        public PartitionRowKeyTuple BuildTableKey(object propertyValue)
+        {
+            return new PartitionRowKeyTuple($"Index_{sagaTypeName}_{propertyName}_{Serialize(propertyValue)}", "");
+        }
+
+        private static string Serialize(object propertyValue)
+        {
+            using (var sw = new StringWriter())
+            {
+                new JsonSerializer().Serialize(sw, propertyValue);
+                sw.Flush();
+                return sw.ToString();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/LRUCache.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/LRUCache.cs
@@ -1,0 +1,93 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System.Collections.Generic;
+
+    public sealed class LRUCache<TKey, TValue>
+    {
+        readonly LinkedList<Item> lru = new LinkedList<Item>();
+        readonly Dictionary<TKey, LinkedListNode<Item>> items = new Dictionary<TKey, LinkedListNode<Item>>();
+
+        readonly int capacity;
+        readonly object @lock = new object();
+
+        private class Item
+        {
+            public TKey Key;
+            public TValue Value;
+        }
+
+        public LRUCache(int capacity)
+        {
+            this.capacity = capacity;
+        }
+
+        public bool TryGet(TKey key, out TValue value)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node))
+                {
+                    lru.Remove(node);
+                    lru.AddLast(node);
+                    value = node.Value.Value;
+                    return true;
+                }
+
+                value = default(TValue);
+                return false;
+            }
+        }
+
+        public void Put(TKey key, TValue value)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node) == false)
+                {
+                    node = new LinkedListNode<Item>(
+                        new Item
+                        {
+                            Key = key,
+                            Value = value
+                        });
+                    items.Add(key, node);
+
+                    TrimOneIfNeeded();
+                }
+                else
+                {
+                    // just update the value
+                    node.Value.Value = value;
+                    lru.Remove(node);
+                }
+
+                lru.AddLast(node);
+            }
+        }
+
+        public void Remove(TKey key)
+        {
+            lock (@lock)
+            {
+                LinkedListNode<Item> node;
+                if (items.TryGetValue(key, out node))
+                {
+                    lru.Remove(node);
+                    items.Remove(key);
+                }
+            }
+        }
+
+        private void TrimOneIfNeeded()
+        {
+            if (items.Count > 0 && items.Count > capacity)
+            {
+                var node = lru.First;
+                lru.Remove(node);
+                items.Remove(node.Value.Key);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/PartitionRowKeyTuple.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/PartitionRowKeyTuple.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    public sealed class PartitionRowKeyTuple
+    {
+        public string PartitionKey { get; }
+        public string RowKey { get; }
+
+        public PartitionRowKeyTuple(string partitionKey, string rowKey)
+        {
+            PartitionKey = partitionKey;
+            RowKey = rowKey;
+        }
+
+        public void Apply(ITableEntity entity)
+        {
+            entity.PartitionKey = PartitionKey;
+            entity.RowKey = RowKey;
+        }
+
+        private bool Equals(PartitionRowKeyTuple other)
+        {
+            return string.Equals(PartitionKey, other.PartitionKey) && string.Equals(RowKey, other.RowKey);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+            return Equals((PartitionRowKeyTuple) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((PartitionKey?.GetHashCode() ?? 0)*397) ^ (RowKey?.GetHashCode() ?? 0);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SagaDataSerializer.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SagaDataSerializer.cs
@@ -1,0 +1,71 @@
+namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+    using NServiceBus.Saga;
+
+    /// <summary>
+    /// A helper saga data serializer for internal purposes
+    /// </summary>
+    internal class SagaDataSerializer
+    {
+        public static byte[] SerializeSagaData<TSagaData>(TSagaData sagaData) where TSagaData : IContainSagaData
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new SagaOnlyPropertiesDataContractResolver()
+            };
+
+            using (var ms = new MemoryStream())
+            {
+                using (var zipped = new GZipStream(ms, CompressionMode.Compress))
+                {
+                    using (var sw = new StreamWriter(zipped))
+                    {
+                        serializer.Serialize(sw, sagaData);
+                        sw.Flush();
+                    }
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        public static IContainSagaData DeserializeSagaData(Type sagaType, byte[] value)
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new SagaOnlyPropertiesDataContractResolver()
+            };
+
+            using (var ms = new MemoryStream(value))
+            {
+                using (var zipped = new GZipStream(ms, CompressionMode.Decompress))
+                {
+                    using (var sr = new StreamReader(zipped))
+                    {
+                        return (IContainSagaData)serializer.Deserialize(sr, sagaType);
+                    }
+                }
+            }
+        }
+
+        private class SagaOnlyPropertiesDataContractResolver : DefaultContractResolver
+        {
+            public SagaOnlyPropertiesDataContractResolver() : base(true) // for performance
+            {
+            }
+
+            protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+            {
+                var properties = new HashSet<string>(AzureSagaPersister.SelectPropertiesToPersist(type).Select(pi => pi.Name));
+                return base.CreateProperties(type, memberSerialization).Where(p => properties.Contains(p.PropertyName)).ToArray();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -1,0 +1,215 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Linq.Expressions;
+    using System.Net;
+    using System.Reflection;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using Newtonsoft.Json;
+    using NServiceBus.Saga;
+
+    public class SecondaryIndexPersister
+    {
+        readonly Func<Type, CloudTable> getTableForSaga;
+        readonly ScanForSaga scanner;
+        readonly Action<IContainSagaData> persist;
+        
+        const int LRUCapacity = 1000;
+        readonly LRUCache<PartitionRowKeyTuple, Guid> cache = new LRUCache<PartitionRowKeyTuple, Guid>(LRUCapacity);
+
+        public SecondaryIndexPersister(Func<Type, CloudTable> getTableForSaga, ScanForSaga scanner, Action<IContainSagaData> persist)
+        {
+            this.getTableForSaga = getTableForSaga;
+            this.scanner = scanner;
+            this.persist = persist;
+        }
+
+        public delegate Guid? ScanForSaga(Type sagaType, string propertyName, object propertyValue);
+
+        public void Insert(IContainSagaData sagaData)
+        {
+            var sagaType = sagaData.GetType();
+            var table = getTableForSaga(sagaType);
+            var ix = IndexDefintion.Get(sagaType);
+            if (ix == null)
+            {
+                return;
+            }
+
+            var propertyValue = ix.Accessor(sagaData);
+            var key = ix.BuildTableKey(propertyValue);
+
+            var entity = new SecondaryIndexTableEntity
+            {
+                SagaId = sagaData.Id,
+                InitialSagaData = SagaDataSerializer.SerializeSagaData(sagaData),
+                PartitionKey = key.PartitionKey,
+                RowKey = key.RowKey
+            };
+
+            // the insert plan is following:
+            // 1) try insert the 2nd index row
+            // 2) if it fails, another worker has done it
+            // 3) ensure that the primary is stored, throwing an exception afterwards in any way
+
+            try
+            {
+                table.Execute(TableOperation.Insert(entity));
+            }
+            catch (StorageException ex)
+            {
+                var indexRowAlreadyExists = IsConflict(ex);
+                if (indexRowAlreadyExists)
+                {
+                    var indexRow = table.Execute(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.RowKey)).Result as SecondaryIndexTableEntity;
+                    var data = indexRow?.InitialSagaData;
+                    if (data != null)
+                    {
+                        var deserializeSagaData = SagaDataSerializer.DeserializeSagaData(sagaType, data);
+
+                        // saga hasn't been saved under primary key. Try to store it
+                        try
+                        {
+                            persist(deserializeSagaData);
+                        }
+                        catch (StorageException e)
+                        {
+                            if (IsConflict(e))
+                            {
+                                // swallow ex as another worker created the primary under this key
+                            }
+                        }
+                    }
+
+                    throw new RetryNeededException();
+                }
+
+                throw;
+            }
+        }
+
+        public Guid? FindPossiblyCreatingIndexEntry<TSagaData>(string propertyName, object propertyValue)
+            where TSagaData : IContainSagaData
+        {
+            var sagaType = typeof(TSagaData);
+            var ix = IndexDefintion.Get(sagaType);
+            if (ix == null)
+            {
+                throw new ArgumentException($"Saga {typeof(TSagaData)} has no correlation properties. Ensure that your saga is correlated by this property and only then, mark it with `Unique` attribute.");
+            }
+
+            ix.ValidateProperty(propertyName);
+
+            var key = ix.BuildTableKey(propertyValue);
+
+            Guid guid;
+            if (cache.TryGet(key, out guid))
+            {
+                return guid;
+            }
+
+            var table = getTableForSaga(sagaType);
+            var secondaryIndexEntry = table.Execute(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.RowKey)).Result as SecondaryIndexTableEntity;
+            if (secondaryIndexEntry != null)
+            {
+                cache.Put(key, secondaryIndexEntry.SagaId);
+                return secondaryIndexEntry.SagaId;
+            }
+
+            var sagaId = scanner(sagaType, propertyName, propertyValue);
+            if (sagaId == null)
+            {
+                return null;
+            }
+
+            var entity = new SecondaryIndexTableEntity();
+            key.Apply(entity);
+            entity.SagaId = sagaId.Value;
+
+            try
+            {
+                table.Execute(TableOperation.Insert(entity));
+            }
+            catch (StorageException)
+            {
+                throw new RetryNeededException();
+            }
+
+            cache.Put(key, sagaId.Value);
+            return sagaId;
+        }
+
+        private static bool IsConflict(StorageException ex)
+        {
+            return ex.RequestInformation.HttpStatusCode == (int) HttpStatusCode.Conflict;
+        }
+
+        private class IndexDefintion
+        {
+            static readonly ConcurrentDictionary<Type, object> sagaToIndex = new ConcurrentDictionary<Type, object>();
+            static readonly object NullValue = new object();
+
+            static readonly ParameterExpression ObjectParameter = Expression.Parameter(typeof(object));
+
+            readonly string sagaTypeName;
+            readonly string propertyName;
+
+            public Func<object, object> Accessor { get; }
+
+            private IndexDefintion(Type sagaType, PropertyInfo pi)
+            {
+                sagaTypeName = sagaType.FullName;
+                propertyName = pi.Name;
+                Accessor = Expression.Lambda<Func<object, object>>(Expression.Convert(Expression.MakeMemberAccess(Expression.Convert(ObjectParameter, sagaType), pi), typeof(object)), ObjectParameter).Compile();
+            }
+
+            public static IndexDefintion Get(Type sagaType)
+            {
+                var index = sagaToIndex.GetOrAdd(sagaType, type =>
+                {
+                    var pi = UniqueAttribute.GetUniqueProperty(sagaType);
+                    if (pi == null)
+                    {
+                        return NullValue;
+                    }
+
+                    return new IndexDefintion(sagaType, pi);
+                });
+
+                if (ReferenceEquals(index, NullValue))
+                {
+                    return null;
+                }
+
+                return (IndexDefintion) index;
+            }
+
+            public void ValidateProperty(string propertyName)
+            {
+                if (this.propertyName != propertyName)
+                {
+                    throw new ArgumentException($"The following saga '{sagaTypeName} is not indexed by '{propertyName}'. The only secondary index is defined for '{this.propertyName}'. " +
+                                                $"Ensure that the saga is correlated properly.");
+                }
+            }
+
+            public PartitionRowKeyTuple BuildTableKey(object propertyValue)
+            {
+                return new PartitionRowKeyTuple($"Index_{sagaTypeName}", $"{propertyName}_{Serialize(propertyValue)}");
+            }
+
+            private static string Serialize(object propertyValue)
+            {
+                using (var sw = new StringWriter())
+                {
+                    new JsonSerializer().Serialize(sw, propertyValue);
+                    sw.Flush();
+                    return sw.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -197,7 +197,7 @@
 
             public PartitionRowKeyTuple BuildTableKey(object propertyValue)
             {
-                return new PartitionRowKeyTuple($"Index_{sagaTypeName}", $"{propertyName}_{Serialize(propertyValue)}");
+                return new PartitionRowKeyTuple($"Index_{sagaTypeName}_{propertyName}_{Serialize(propertyValue)}", "");
             }
 
             private static string Serialize(object propertyValue)

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexPersister.cs
@@ -1,14 +1,9 @@
 ﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
 {
     using System;
-    using System.Collections.Concurrent;
-    using System.IO;
-    using System.Linq.Expressions;
     using System.Net;
-    using System.Reflection;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
-    using Newtonsoft.Json;
     using NServiceBus.Saga;
 
     public class SecondaryIndexPersister
@@ -144,71 +139,6 @@
         private static bool IsConflict(StorageException ex)
         {
             return ex.RequestInformation.HttpStatusCode == (int) HttpStatusCode.Conflict;
-        }
-
-        private class IndexDefintion
-        {
-            static readonly ConcurrentDictionary<Type, object> sagaToIndex = new ConcurrentDictionary<Type, object>();
-            static readonly object NullValue = new object();
-
-            static readonly ParameterExpression ObjectParameter = Expression.Parameter(typeof(object));
-            readonly string propertyName;
-
-            readonly string sagaTypeName;
-
-            private IndexDefintion(Type sagaType, PropertyInfo pi)
-            {
-                sagaTypeName = sagaType.FullName;
-                propertyName = pi.Name;
-                Accessor = Expression.Lambda<Func<object, object>>(Expression.Convert(Expression.MakeMemberAccess(Expression.Convert(ObjectParameter, sagaType), pi), typeof(object)), ObjectParameter).Compile();
-            }
-
-            public Func<object, object> Accessor { get; }
-
-            public static IndexDefintion Get(Type sagaType)
-            {
-                var index = sagaToIndex.GetOrAdd(sagaType, type =>
-                {
-                    var pi = UniqueAttribute.GetUniqueProperty(sagaType);
-                    if (pi == null)
-                    {
-                        return NullValue;
-                    }
-
-                    return new IndexDefintion(sagaType, pi);
-                });
-
-                if (ReferenceEquals(index, NullValue))
-                {
-                    return null;
-                }
-
-                return (IndexDefintion) index;
-            }
-
-            public void ValidateProperty(string propertyName)
-            {
-                if (this.propertyName != propertyName)
-                {
-                    throw new ArgumentException($"The following saga '{sagaTypeName}' is not indexed by '{propertyName}'. The only secondary index is defined for '{this.propertyName}'. " +
-                                                $"Ensure that the saga is correlated properly.");
-                }
-            }
-
-            public PartitionRowKeyTuple BuildTableKey(object propertyValue)
-            {
-                return new PartitionRowKeyTuple($"Index_{sagaTypeName}_{propertyName}_{Serialize(propertyValue)}", "");
-            }
-
-            private static string Serialize(object propertyValue)
-            {
-                using (var sw = new StringWriter())
-                {
-                    new JsonSerializer().Serialize(sw, propertyValue);
-                    sw.Flush();
-                    return sw.ToString();
-                }
-            }
         }
     }
 }

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexTableEntity.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/Azure/SecondaryIndeces/SecondaryIndexTableEntity.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.SagaPersisters.Azure.SecondaryIndeces
+{
+    using System;
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    /// <summary>
+    /// An entity holding information about the secondary index.
+    /// </summary>
+    public class SecondaryIndexTableEntity : TableEntity
+    {
+        public Guid SagaId { get; set; }
+
+        public byte[] InitialSagaData { get; set; }
+    }
+}

--- a/src/NServiceBus.AzureStoragePersistence/Timeout/Config/AzureStorageTimeoutPersistence.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Timeout/Config/AzureStorageTimeoutPersistence.cs
@@ -46,6 +46,7 @@ namespace NServiceBus
                 timeoutTable.CreateIfNotExists();
 
                 var timeoutManagerTable = account.CreateCloudTableClient().GetTableReference(timeoutManagerDataTableName);
+
                 timeoutManagerTable.CreateIfNotExists();
 
                 var container = account.CreateCloudBlobClient().GetContainerReference(timeoutStateContainerName);


### PR DESCRIPTION
Connects to: #26

This PR slightly changes the semantics of the issue, requiring sagas to be correlated properly rather then ensuring the number of sagas created. This enables to assert on number of completed sagas, rather then querying for sagas entities.