### PR TITLE
Use nservicebus persistence as default connection string

### DIFF
--- a/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/NServiceBus.AzureStoragePersistence.AcceptanceTests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.AcceptanceTests/NServiceBus.AzureStoragePersistence.AcceptanceTests.csproj
@@ -144,7 +144,9 @@
       <Name>NServiceBus.AzureStoragePersistence</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/NServiceBus.AzureStoragePersistence.ComponentTests.csproj
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/NServiceBus.AzureStoragePersistence.ComponentTests.csproj
@@ -119,6 +119,8 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/Persisters/When_using_AzureStorageSagaGuard.cs
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/Persisters/When_using_AzureStorageSagaGuard.cs
@@ -19,7 +19,6 @@
         public void Should_validate_all_default_settings_for_a_new_config()
         {
             var config = new AzureSagaPersisterConfig();
-            Assert.AreEqual(AzureStorageSagaDefaults.ConnectionString, config.ConnectionString);
             Assert.AreEqual(AzureStorageSagaDefaults.CreateSchema, config.CreateSchema);
         }
     }

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/Persisters/When_using_AzureSubscriptionStorageGuard.cs
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/Persisters/When_using_AzureSubscriptionStorageGuard.cs
@@ -34,7 +34,6 @@
         public void Should_validate_all_default_settings_for_a_new_config()
         {
             var config = new AzureSubscriptionStorageConfig();
-            Assert.AreEqual(AzureSubscriptionStorageDefaults.ConnectionString, config.ConnectionString);
             Assert.AreEqual(AzureSubscriptionStorageDefaults.CreateSchema, config.CreateSchema);
             Assert.AreEqual(AzureSubscriptionStorageDefaults.TableName, config.TableName);
         }

--- a/src/NServiceBus.AzureStoragePersistence.ComponentTests/Persisters/When_using_AzureTimeoutStorageGuard.cs
+++ b/src/NServiceBus.AzureStoragePersistence.ComponentTests/Persisters/When_using_AzureTimeoutStorageGuard.cs
@@ -43,7 +43,6 @@
         public void Should_validate_all_default_settings_for_a_new_config()
         {
             var config = new AzureTimeoutPersisterConfig();
-            Assert.AreEqual(AzureTimeoutStorageDefaults.ConnectionString, config.ConnectionString);
             Assert.AreEqual(AzureTimeoutStorageDefaults.TimeoutManagerDataTableName, config.TimeoutManagerDataTableName);
             Assert.AreEqual(AzureTimeoutStorageDefaults.TimeoutDataTableName, config.TimeoutDataTableName);
             Assert.AreEqual(AzureTimeoutStorageDefaults.PartitionKeyScope, config.PartitionKeyScope);

--- a/src/NServiceBus.AzureStoragePersistence/Config/AzureSagaPersisterConfig.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Config/AzureSagaPersisterConfig.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Config
     {
         public AzureSagaPersisterConfig()
         {
-            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), AzureStorageSagaDefaults.ConnectionString,
+            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), null,
     null, new CallbackValidator(typeof(string), AzureStorageSagaGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
 
             Properties.Add(new ConfigurationProperty("CreateSchema", typeof(bool), AzureStorageSagaDefaults.CreateSchema,

--- a/src/NServiceBus.AzureStoragePersistence/Config/AzureSagaPersisterConfig.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Config/AzureSagaPersisterConfig.cs
@@ -10,8 +10,10 @@ namespace NServiceBus.Config
     {
         public AzureSagaPersisterConfig()
         {
-            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), null,
-    null, new CallbackValidator(typeof(string), AzureStorageSagaGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
+            var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
+
+            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), defaultConnectionString,
+                null, new CallbackValidator(typeof(string), AzureStorageSagaGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
 
             Properties.Add(new ConfigurationProperty("CreateSchema", typeof(bool), AzureStorageSagaDefaults.CreateSchema,
                 ConfigurationPropertyOptions.None));

--- a/src/NServiceBus.AzureStoragePersistence/Config/AzureSubscriptionStorageConfig.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Config/AzureSubscriptionStorageConfig.cs
@@ -7,7 +7,9 @@ namespace NServiceBus.Config
     {
         public AzureSubscriptionStorageConfig()
         {
-            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), null,
+            var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
+
+            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), defaultConnectionString,
                 null, new CallbackValidator(typeof(string), AzureSubscriptionStorageGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
             
             Properties.Add(new ConfigurationProperty("TableName", typeof(string), AzureSubscriptionStorageDefaults.TableName,

--- a/src/NServiceBus.AzureStoragePersistence/Config/AzureSubscriptionStorageConfig.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Config/AzureSubscriptionStorageConfig.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Config
     {
         public AzureSubscriptionStorageConfig()
         {
-            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), AzureSubscriptionStorageDefaults.ConnectionString,
+            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), null,
                 null, new CallbackValidator(typeof(string), AzureSubscriptionStorageGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
             
             Properties.Add(new ConfigurationProperty("TableName", typeof(string), AzureSubscriptionStorageDefaults.TableName,

--- a/src/NServiceBus.AzureStoragePersistence/Config/AzureTimeoutPersisterConfig.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Config/AzureTimeoutPersisterConfig.cs
@@ -10,7 +10,9 @@ namespace NServiceBus.Config
     {
         public AzureTimeoutPersisterConfig()
         {
-            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), null,
+            var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
+
+            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), defaultConnectionString,
                 null, new CallbackValidator(typeof(string), AzureTimeoutStorageGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
 
             Properties.Add(new ConfigurationProperty("TimeoutManagerDataTableName", typeof(string), AzureTimeoutStorageDefaults.TimeoutManagerDataTableName,

--- a/src/NServiceBus.AzureStoragePersistence/Config/AzureTimeoutPersisterConfig.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Config/AzureTimeoutPersisterConfig.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Config
     {
         public AzureTimeoutPersisterConfig()
         {
-            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), AzureTimeoutStorageDefaults.ConnectionString,
+            Properties.Add(new ConfigurationProperty("ConnectionString", typeof(string), null,
                 null, new CallbackValidator(typeof(string), AzureTimeoutStorageGuard.CheckConnectionString), ConfigurationPropertyOptions.None));
 
             Properties.Add(new ConfigurationProperty("TimeoutManagerDataTableName", typeof(string), AzureTimeoutStorageDefaults.TimeoutManagerDataTableName,

--- a/src/NServiceBus.AzureStoragePersistence/SagaPersisters/AzureStorageSagaDefaults.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SagaPersisters/AzureStorageSagaDefaults.cs
@@ -2,7 +2,6 @@
 {
     public class AzureStorageSagaDefaults
     {
-        public const string ConnectionString = "UseDevelopmentStorage=true";
         public const bool CreateSchema = true;
     }
 }

--- a/src/NServiceBus.AzureStoragePersistence/Subscriptions/AzureSubscriptionStorageDefaults.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Subscriptions/AzureSubscriptionStorageDefaults.cs
@@ -2,7 +2,6 @@
 {
     public class AzureSubscriptionStorageDefaults
     {
-        public const string ConnectionString = "UseDevelopmentStorage=true";
         public const bool CreateSchema = true;
         public const string TableName = "Subscription";
     }

--- a/src/NServiceBus.AzureStoragePersistence/Timeout/AzureTimeoutStorageDefaults.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Timeout/AzureTimeoutStorageDefaults.cs
@@ -3,10 +3,6 @@
     public class AzureTimeoutStorageDefaults
     {
         /// <summary>
-        /// Azure Storage connection string. Default is to use Development Storage.
-        /// </summary>
-        public const string ConnectionString = "UseDevelopmentStorage=true";
-        /// <summary>
         /// Azure Storage table name for Timeout Manager Data. Default is 'TimeoutManagerDataTable'.
         /// </summary>
         public const string TimeoutManagerDataTableName = "TimeoutManagerDataTable";


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.AzureStoragePersistence/issues/8

Depends on https://github.com/Particular/NServiceBus.AzureStoragePersistence/pull/33 being merged first

Checks if there is an appsetting specified for `NServiceBus/Persistence` and uses that as the default connection string.

If a more specific connection string is specified (using the specific `configSection` or code config) then this is ignored.

If no value is provided for either the `NServiceBus/Persistence` appSetting or the `configSection` then the normal Guard process throws an `ArgumentException` referring to the connection string

- [x] Implement
- [x] Merge dependent PR
- [x] Document