### PR TITLE
Fixed the SafeFirstOrDefault errors

### DIFF
--- a/src/NServiceBus.AzureStoragePersistence/SafeLinqExtensions.cs
+++ b/src/NServiceBus.AzureStoragePersistence/SafeLinqExtensions.cs
@@ -8,6 +8,8 @@ namespace NServiceBus.Azure
     {
         public static TSource SafeFirstOrDefault<TSource>(this IEnumerable<TSource> source)
         {
+            if (source == null) return default(TSource);
+
             try
             {
                 return source.FirstOrDefault();

--- a/src/NServiceBus.AzureStoragePersistence/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.AzureStoragePersistence/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -104,7 +104,7 @@
 
             var result = query
                 .Take(1000)
-                .ToList()
+                .ToList() //must happen locally because OrderBy is not supported by native Azure Storage Table service
                 .OrderBy(c => c.Time);
 
             var allTimeouts = result.ToList();
@@ -125,12 +125,11 @@
             }
 
             var future = futureTimeouts.SafeFirstOrDefault();
-            nextTimeToRunQuery = lastSuccessfulRead.HasValue ? lastSuccessfulRead.Value
-                                        : (future != null ? future.Time : now.AddSeconds(1));
+            nextTimeToRunQuery = lastSuccessfulRead ?? (future?.Time ?? now.AddSeconds(1));
                 
             results = pastTimeouts
                 .Where(c => !string.IsNullOrEmpty(c.RowKey))
-                .Select(c => new Tuple<String, DateTime>(c.RowKey, c.Time))
+                .Select(c => new Tuple<string, DateTime>(c.RowKey, c.Time))
                 .Distinct()
                 .ToList();
 
@@ -345,7 +344,7 @@
         {
             result = (from c in timeoutDataTable.CreateQuery<TimeoutDataEntity>()
                       where c.PartitionKey == partitionKey && c.RowKey == rowKey // issue #191 cannot occur when both partitionkey and rowkey are specified
-                      select c).ToList().SafeFirstOrDefault();
+                      select c).SafeFirstOrDefault();
 
             return result != null;
 


### PR DESCRIPTION
Connected to #36

Added null check on SafeFirstOrDefault and removed any unnecessary uses of ToList near where it is used.

Found one location where there was a ToList() near an OrderBy. Added a comment for what that is needed.

Cleaned up a few bits of code.

This is ready for review and merge @Particular/azure-maintainers 